### PR TITLE
Fix/qt eventloop handling

### DIFF
--- a/Int-Ball2_platform_gse/src/ground_system/debug_gui/src/main.cpp
+++ b/Int-Ball2_platform_gse/src/ground_system/debug_gui/src/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QTimer>
 #include <ros/ros.h>
 #include "debug_main_window.h"
 #include "debug_gui_config.h"
@@ -95,13 +96,15 @@ int main(int argc, char *argv[])
     w.setWindowFlags(Qt::WindowType::CustomizeWindowHint | Qt::WindowType::WindowCloseButtonHint | Qt::WindowType::WindowMaximizeButtonHint);
     w.showMaximized();
 
-    ros::Rate rate(30);
-    while(ros::ok())
-    {
-        ros::spinOnce();
-        a.processEvents();
-        rate.sleep();
-    }
+    QTimer ros_timer;
+    QObject::connect(&ros_timer, &QTimer::timeout, []() {
+        if (ros::ok()) {
+            ros::spinOnce();
+        } else {
+            QApplication::quit();
+        }
+    });
+    ros_timer.start(33);  // ~30 Hz
 
-    return 0;
+    return a.exec();
 }

--- a/Int-Ball2_platform_gse/src/ground_system/operator_gui/src/main.cpp
+++ b/Int-Ball2_platform_gse/src/ground_system/operator_gui/src/main.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QTimer>
 #include <ros/ros.h>
 #include "ground_system_main_window.h"
 #include "gui_color.h"
@@ -104,14 +105,18 @@ int main(int argc, char *argv[])
                   availableGeometry.width(),
                   availableGeometry.height());
 
-    ros::Rate rate(60);
-    while(ros::ok())
-    {
-        ros::spinOnce();
-        a.processEvents();
-        rate.sleep();
-    }
-    spdlog::shutdown();
+    QTimer ros_timer;
+    QObject::connect(&ros_timer, &QTimer::timeout, []() {
+        if (ros::ok()) {
+            ros::spinOnce();
+        } else {
+            QApplication::quit();
+        }
+    });
+    ros_timer.start(16);  // ~60 Hz
 
-    return 0;
+    int ret = a.exec();
+
+    spdlog::shutdown();
+    return ret;
 }

--- a/Int-Ball2_platform_gse/src/ground_system/platform_gui/src/main.cpp
+++ b/Int-Ball2_platform_gse/src/ground_system/platform_gui/src/main.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QPushButton>
+#include <QTimer>
 #include <ros/ros.h>
 #include "platform_main_window.h"
 #include "platform_gui_config.h"
@@ -96,14 +97,15 @@ int main(int argc, char *argv[])
     w.setWindowFlags(Qt::WindowType::CustomizeWindowHint | Qt::WindowType::WindowCloseButtonHint | Qt::WindowType::WindowMaximizeButtonHint);
     w.showMaximized();
 
-    ros::Rate rate(30);
-    while(ros::ok())
-    {
-        ros::spinOnce();
-        a.processEvents();
-        rate.sleep();
-    }
-    //spdlog::shutdown();
+    QTimer ros_timer;
+    QObject::connect(&ros_timer, &QTimer::timeout, []() {
+        if (ros::ok()) {
+            ros::spinOnce();
+        } else {
+            QApplication::quit();
+        }
+    });
+    ros_timer.start(33); // ~30 Hz
 
-    return 0;
+    return a.exec();
 }


### PR DESCRIPTION
Hello, first of all, thank you for providing this simulator!
This PR aims to fix an incorrect ROS–Qt integration pattern that caused GUI windows to appear blank or become unresponsive when launched via `roslaunch` or `rosrun` (both when run locally or in a docker container).
This issue was present in the main.cpp files of the three GUIs (debug_gui, platform_gui and operator_gui) and came from manually constructing the Qt eventloop with `processEvents` instead of running the Qt event loop. Reference to the qt docs: https://doc.qt.io/qt-6/qcoreapplication.html#the-event-loop-and-event-handling

To solve this, this PR applies the following changes:

- Removed manual `while(ros::ok())` loops
- Removed calls to `QApplication::processEvents()`
- Introduced a `QTimer` that periodically calls `ros::spinOnce()`
- Added `QApplication::exec()` as the main loop exit point
- Ensured clean shutdown when ROS is no longer running

This results in Qt now owning the main event loop which leads to the GUIs being responsive and stable both locally and in docker with X11.
No functional GUI behavior was changed.