### PR TITLE
Fix operator precedence bug in controlFreqFluctuation() frequency guard

### DIFF
--- a/Int-Ball2_platform_simulator/src/platform_sim/simulation/plugins/nav/src/nav.cpp
+++ b/Int-Ball2_platform_simulator/src/platform_sim/simulation/plugins/nav/src/nav.cpp
@@ -674,7 +674,7 @@ double gazebo::Nav::controlFreqFluctuation()
 	double               freq = gain_cnt_ * sin(2.0 * M_PI * freq_cnt_ * t.Double()) + wg;
 	
 	// Convert Freq[Hz] to Duration[s]	
-	assert(std::abs(freq > EPS));
+	assert(std::abs(freq) > EPS);
 	double duration = 1.0 / freq;
 
 	return duration;


### PR DESCRIPTION
Fixes #1.

`assert(std::abs(freq > EPS))` takes the absolute value of the *boolean result* of `freq > EPS` (always 0 or 1), not of `freq` itself - it's functionally just `assert(freq > EPS)`.

`freq` is a Gaussian-perturbed sinusoid, negative roughly half the time by design, so this guard aborts on any safe negative frequency, not just genuinely-near-zero ones. Fixed to `assert(std::abs(freq) > EPS)`, matching the same pattern already used a few lines below (`std::abs(m) > EPS`).

Couldn't build the real Gazebo/ROS target here, so verified the guard's logic in isolation:
```
large negative freq - safe, but should NOT trigger the guard (freq=-5): buggy=0 fixed=1 expected_safe=1
CONFIRMED BUG: buggy_check(-5.0) == false means the original assert(std::abs(freq > EPS)) WOULD ABORT on a safe negative freq.
FIXED LOGIC PASS
```
